### PR TITLE
Update to MacOS 14 and Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   build:
-    uses: yetanalytics/workflow-runtimer/.github/workflows/runtimer.yml@af5aff2ec2914a9a708e6875b2be3a6485c68140
+    # Update the SHA to test changes
+    uses: yetanalytics/workflow-runtimer/.github/workflows/runtimer.yml@e0eb98e881f13d046ccaa1769be6186d1d8d5399
     with:
       java-version: '11'
       java-distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,14 @@ jobs:
       - name: Download ubuntu-latest Artifact
         uses: actions/download-artifact@v4
         with:
-          name: ubuntu-20.04-jre
+          name: ubuntu-22.04-jre
 
       - name: Download macOS-latest Artifact
         uses: actions/download-artifact@v4
         with:
-          name: macos-12-jre
+          name: macos-14-jre
 
       - name: Download windows-latest Artifact
         uses: actions/download-artifact@v4
         with:
           name: windows-2022-jre
-

--- a/.github/workflows/runtimer.yml
+++ b/.github/workflows/runtimer.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-12, windows-2022]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/runtimer.yml
+++ b/.github/workflows/runtimer.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This repo contains a [reusable workflow](https://docs.github.com/en/actions/lear
 ```
 
 This will create runtimes for the following operating systems:
-- MacOS Monterey 12
-- Ubuntu 20.04
+- MacOS Sonoma 14
+- Ubuntu 22.04
 - Windows Server 2022
-


### PR DESCRIPTION
Prompted by the fact that [MacOS 12 will be deprecated soon](https://github.com/actions/runner-images/issues/10721).